### PR TITLE
BACKLOG-10740: Use redux to store the size of the Content Tree

### DIFF
--- a/src/javascript/ContentManager/ContentManager.redux-actions.js
+++ b/src/javascript/ContentManager/ContentManager.redux-actions.js
@@ -1,6 +1,7 @@
 const CM_NAVIGATE = 'CM_NAVIGATE';
 const CM_SET_UILANGUAGE = 'CM_SET_UILANGUAGE';
 const CM_SET_TREE = 'CM_SET_TREE';
+const CM_SET_TREE_WIDTH = 'CM_SET_TREE_WIDTH';
 const CM_SET_OPEN_PATHS = 'CM_SET_OPEN_PATHS';
 const CM_SET_SEARCH_MODE = 'CM_SET_SEARCH_MODE';
 const CM_ADD_PATHS_TO_REFETCH = 'CM_ADD_PATHS_TO_REFETCH';
@@ -91,6 +92,13 @@ function cmSetTreeState(state) {
     };
 }
 
+function cmSetTreeWidth(width) {
+    return {
+        type: CM_SET_TREE_WIDTH,
+        width: width
+    };
+}
+
 function cmSetSearchMode(searchMode) {
     return {
         type: CM_SET_SEARCH_MODE,
@@ -102,6 +110,7 @@ export {
     CM_NAVIGATE,
     CM_SET_UILANGUAGE,
     CM_SET_TREE,
+    CM_SET_TREE_WIDTH,
     CM_SET_OPEN_PATHS,
     CM_SET_SEARCH_MODE,
     CM_DRAWER_STATES,
@@ -122,6 +131,7 @@ export {
     cmOpenPaths,
     cmClosePaths,
     cmSetTreeState,
+    cmSetTreeWidth,
     cmSetSearchMode,
     cmAddPathsToRefetch,
     cmRemovePathsToRefetch

--- a/src/javascript/ContentManager/ContentManager.redux-reducers.js
+++ b/src/javascript/ContentManager/ContentManager.redux-reducers.js
@@ -7,11 +7,13 @@ import {
     CM_SET_OPEN_PATHS,
     CM_SET_SEARCH_MODE,
     CM_SET_TREE,
+    CM_SET_TREE_WIDTH,
     CM_SET_UILANGUAGE
 } from './ContentManager.redux-actions';
 import * as _ from 'lodash';
 import {extractPaths} from './ContentManager.utils';
 import {CM_SET_PREVIEW} from './preview.redux-actions';
+import ContentManagerStyleConstants from './ContentManager.style-constants';
 
 let uiLanguageReducer = dxContext => (state = dxContext.uilang, action) => {
     if (action.uiLang && action.type === CM_SET_UILANGUAGE) {
@@ -122,6 +124,14 @@ let treeStateReducer = (state = CM_DRAWER_STATES.SHOW, action) => {
     }
 };
 
+let treeWidthReducer = (state = ContentManagerStyleConstants.treeDrawerWidth, action) => {
+    if (action.type === CM_SET_TREE_WIDTH) {
+        return action.width;
+    }
+
+    return state;
+};
+
 let pathsToRefetchReducer = (state, action) => {
     if (state === undefined) {
         state = [];
@@ -142,4 +152,8 @@ let searchModeReducer = params => (state = (params.sql2SearchFrom ? 'sql2' : 'no
     return state;
 };
 
-export {languageReducer, uiLanguageReducer, siteReducer, modeReducer, pathReducer, paramsReducer, openPathsReducer, treeStateReducer, searchModeReducer, siteDisplayableNameReducer, pathsToRefetchReducer, availableLanguagesReducer};
+export {
+    languageReducer, uiLanguageReducer, siteReducer, modeReducer, pathReducer, paramsReducer, openPathsReducer,
+    treeStateReducer, treeWidthReducer, searchModeReducer, siteDisplayableNameReducer, pathsToRefetchReducer,
+    availableLanguagesReducer
+};

--- a/src/javascript/ContentManager/ContentManager.redux-store.js
+++ b/src/javascript/ContentManager/ContentManager.redux-store.js
@@ -14,7 +14,10 @@ import {
     uiLanguageReducer,
     openPathsReducer,
     searchModeReducer,
-    siteDisplayableNameReducer, treeStateReducer, pathsToRefetchReducer,
+    siteDisplayableNameReducer,
+    treeStateReducer,
+    treeWidthReducer,
+    pathsToRefetchReducer,
     availableLanguagesReducer
 } from './ContentManager.redux-reducers';
 import {connectRouter, routerMiddleware} from 'connected-react-router';
@@ -39,6 +42,7 @@ let contentManagerReduxStore = (dxContext, history) => {
         previewState: previewStateReducer,
         previewSelection: previewSelectionReducer,
         treeState: treeStateReducer,
+        treeWidth: treeWidthReducer,
         openPaths: openPathsReducer(currentValueFromUrl.site, currentValueFromUrl.path, currentValueFromUrl.mode),
         searchMode: searchModeReducer(currentValueFromUrl.params),
         copyPaste: copyPaste,

--- a/src/javascript/ContentManager/ContentRoute/ContentLayout/ContentLayout.container.jsx
+++ b/src/javascript/ContentManager/ContentRoute/ContentLayout/ContentLayout.container.jsx
@@ -16,7 +16,7 @@ import {
 } from '../../eventHandlerRegistry';
 import {translate} from 'react-i18next';
 import {connect} from 'react-redux';
-import {cmClosePaths, cmGoto, cmOpenPaths, cmRemovePathsToRefetch} from '../../ContentManager.redux-actions';
+import {cmClosePaths, cmGoto, cmOpenPaths, cmRemovePathsToRefetch, cmSetTreeWidth} from '../../ContentManager.redux-actions';
 import ContentManagerConstants from '../../ContentManager.constants';
 import {getNewNodePath, isDescendantOrSelf} from '../../ContentManager.utils';
 import {cmRemoveSelection, cmSwitchSelection} from './contentSelection.redux-actions';
@@ -154,7 +154,12 @@ export class ContentLayoutContainer extends React.Component {
     }
 
     render() {
-        const {notificationContext, t, mode, path, uiLang, lang, siteKey, params, pagination, sort, pathsToRefetch, removePathsToRefetch, setPath, treeState, filesMode, previewState, previewSelection} = this.props;
+        const {
+            notificationContext, t, mode, path, uiLang, lang, siteKey, params, pagination, sort, pathsToRefetch,
+            removePathsToRefetch, setPath, treeState, treeWidth, filesMode, previewState, previewSelection,
+            setTreeWidth
+        } = this.props;
+
         let fetchPolicy = sort.orderBy === 'displayName' ? 'network-only' : 'cache-first';
         // If the path to display is part of the paths to refetch then refetch
         if (!_.isEmpty(pathsToRefetch) && pathsToRefetch.indexOf(path) !== -1) {
@@ -193,13 +198,16 @@ export class ContentLayoutContainer extends React.Component {
                                            path={path}
                                            filesMode={filesMode}
                                            treeState={treeState}
+                                           treeWidth={treeWidth}
                                            previewState={previewState}
                                            previewSelection={previewSelection}
                                            rows={[]}
                                            loading={loading}
                                            totalCount={0}
                                            layoutQuery={layoutQuery}
-                                           layoutQueryParams={layoutQueryParams}/>
+                                           layoutQueryParams={layoutQueryParams}
+                                           setTreeWidth={setTreeWidth}
+                            />
                         );
                     }
 
@@ -238,13 +246,16 @@ export class ContentLayoutContainer extends React.Component {
                                            path={path}
                                            filesMode={filesMode}
                                            treeState={treeState}
+                                           treeWidth={treeWidth}
                                            previewState={previewState}
                                            previewSelection={previewSelection}
                                            rows={rows}
                                            loading={loading}
                                            totalCount={totalCount}
                                            layoutQuery={layoutQuery}
-                                           layoutQueryParams={layoutQueryParams}/>
+                                           layoutQueryParams={layoutQueryParams}
+                                           setTreeWidth={setTreeWidth}
+                            />
                         </React.Fragment>
                     );
                 }}
@@ -268,6 +279,7 @@ const mapStateToProps = state => ({
     openedPaths: state.openPaths,
     pathsToRefetch: state.pathsToRefetch,
     treeState: state.treeState,
+    treeWidth: state.treeWidth,
     selection: state.selection
 });
 
@@ -278,7 +290,8 @@ const mapDispatchToProps = dispatch => ({
     closePaths: paths => dispatch(cmClosePaths(paths)),
     removePathsToRefetch: paths => dispatch(cmRemovePathsToRefetch(paths)),
     removeSelection: path => dispatch(cmRemoveSelection(path)),
-    switchSelection: path => dispatch(cmSwitchSelection(path))
+    switchSelection: path => dispatch(cmSwitchSelection(path)),
+    setTreeWidth: width => dispatch(cmSetTreeWidth(width))
 });
 
 ContentLayoutContainer.propTypes = {
@@ -302,11 +315,13 @@ ContentLayoutContainer.propTypes = {
     t: PropTypes.func.isRequired,
     uiLang: PropTypes.string.isRequired,
     treeState: PropTypes.number.isRequired,
+    treeWidth: PropTypes.number.isRequired,
     previewState: PropTypes.number.isRequired,
     filesMode: PropTypes.string.isRequired,
     selection: PropTypes.array.isRequired,
     removeSelection: PropTypes.func.isRequired,
-    switchSelection: PropTypes.func.isRequired
+    switchSelection: PropTypes.func.isRequired,
+    setTreeWidth: PropTypes.func.isRequired
 };
 
 export default compose(

--- a/src/javascript/ContentManager/ContentRoute/ContentLayout/ContentLayout.jsx
+++ b/src/javascript/ContentManager/ContentRoute/ContentLayout/ContentLayout.jsx
@@ -81,22 +81,16 @@ const styles = theme => ({
 });
 
 export class ContentLayout extends React.Component {
-    constructor(props) {
-        super(props);
-        this.state = {treeWidth: contentManagerStyleConstants.treeDrawerWidth};
-        this.setTreeWidth = this.setTreeWidth.bind(this);
-    }
-
     refreshContentsAndTree(contentTreeConfigs) {
         refetchContentTreeAndListData(contentTreeConfigs);
     }
 
-    setTreeWidth(width) {
-        this.setState({treeWidth: width});
-    }
-
     render() {
-        const {contentTreeConfigs, mode, path, previewState, classes, filesMode, treeState, previewSelection, rows, contentNotFound, totalCount, loading} = this.props;
+        const {
+            contentTreeConfigs, mode, path, previewState, classes, filesMode, treeState, treeWidth, previewSelection, rows, contentNotFound,
+            totalCount, loading, setTreeWidth
+        } = this.props;
+
         let contextualMenu = React.createRef();
         let treeOpen = treeState >= CM_DRAWER_STATES.SHOW && mode !== ContentManagerConstants.mode.SEARCH && mode !== ContentManagerConstants.mode.SQL2SEARCH;
         let previewOpen = previewState >= CM_DRAWER_STATES.SHOW;
@@ -104,17 +98,17 @@ export class ContentLayout extends React.Component {
             <>
                 <div className={classes.root}>
                     <ResizableDrawer
-                            variant="persistent"
-                            anchor="left"
-                            open={treeOpen}
-                            classes={{
-                                root: classes.treeDrawer,
-                                paper: classes.treeDrawerPaper
-                            }}
-                            width={this.state.treeWidth}
-                            onResized={width => this.setTreeWidth(width)}
+                        variant="persistent"
+                        anchor="left"
+                        open={treeOpen}
+                        classes={{
+                            root: classes.treeDrawer,
+                            paper: classes.treeDrawerPaper
+                        }}
+                        width={treeWidth}
+                        onResized={width => setTreeWidth(width)}
                     >
-                        <ContentTrees isOpen={treeOpen} width={this.state.treeWidth}/>
+                        <ContentTrees isOpen={treeOpen} width={treeWidth}/>
                     </ResizableDrawer>
                     <Drawer
                         data-cm-role="preview-drawer"
@@ -137,7 +131,7 @@ export class ContentLayout extends React.Component {
                     <div
                         className={classNames(classes.content)}
                         style={{
-                            marginLeft: treeOpen ? 0 : -this.state.treeWidth,
+                            marginLeft: treeOpen ? 0 : -treeWidth,
                             marginRight: previewOpen ? 0 : -contentManagerStyleConstants.previewDrawerWidth
                         }}
                         onContextMenu={event => contextualMenu.current.open(event)}
@@ -172,13 +166,15 @@ ContentLayout.propTypes = {
     classes: PropTypes.object.isRequired,
     filesMode: PropTypes.string.isRequired,
     treeState: PropTypes.number.isRequired,
+    treeWidth: PropTypes.number.isRequired,
     previewState: PropTypes.number.isRequired,
     contentTreeConfigs: PropTypes.object,
     previewSelection: PropTypes.string,
     rows: PropTypes.array.isRequired,
     contentNotFound: PropTypes.bool,
     totalCount: PropTypes.number.isRequired,
-    loading: PropTypes.bool.isRequired
+    loading: PropTypes.bool.isRequired,
+    setTreeWidth: PropTypes.func.isRequired
 };
 
 export default compose(


### PR DESCRIPTION
The size of the Content Tree is now persisted the same way and as the
same lifecycle as the opened/closed status of the Content Tree and
Previewer.