### PR TITLE
BACKLOG-11479 : add requiredPermmission in zip/Unzip actions

### DIFF
--- a/src/javascript/ContentManager/actions/zipUnzip/unzipAction.jsx
+++ b/src/javascript/ContentManager/actions/zipUnzip/unzipAction.jsx
@@ -10,6 +10,7 @@ export default composeActions(requirementsAction, withNotificationContextAction,
     init: context => {
         context.initRequirements({
             retrieveProperties: {retrievePropertiesNames: ['jcr:mixinTypes']},
+            requiredPermission: 'jcr:addChildNodes',
             retrieveMimeType: true,
             enabled: context => context.node.pipe(map(node => node.children.nodes.length !== 0 && node.children.nodes[0].mimeType.value === 'application/zip' && !isMarkedForDeletion(node)))
         });

--- a/src/javascript/ContentManager/actions/zipUnzip/zipAction.jsx
+++ b/src/javascript/ContentManager/actions/zipUnzip/zipAction.jsx
@@ -8,7 +8,9 @@ import {getNewCounter, removeFileExtension} from '../../ContentManager.utils';
 
 export default composeActions(requirementsAction, withNotificationContextAction, {
     init: context => {
-        context.initRequirements({});
+        context.initRequirements({
+            requiredPermission: 'jcr:addChildNodes'
+        });
     },
     onClick: context => {
         let name = context.node ? context.node.name : (context.nodes.length > 1 ? context.nodes[0].parent.name : context.nodes[0].name);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-11479

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
add requiredPermission in zip and unzip actions to prevent errors when user doesn't have permission to create nodes
