### PR TITLE
QA-12188 : store files_grid_modes into localStorage in order to refre…

### DIFF
--- a/src/javascript/ContentManager/ContentManager.constants.js
+++ b/src/javascript/ContentManager/ContentManager.constants.js
@@ -21,7 +21,9 @@ const ContentManagerConstants = {
         BROWSE: 'browse',
         FILES: 'browse-files',
         SEARCH: 'search',
-        SQL2SEARCH: 'sql2Search'
+        SQL2SEARCH: 'sql2Search',
+        LIST: 'list',
+        GRID: 'grid'
     },
     contentTreeConfigs: {
         contents: {
@@ -48,6 +50,16 @@ const ContentManagerConstants = {
             rootLabel: 'label.contentManager.browseFiles',
             key: 'browse-tree-files'
         }
+    },
+    localStorageKeys: {
+        filesSelectorMode: 'cmm_files_selector_mode',
+        filesSelectorGridMode: 'cmm_files_selector_grid_mode'
+    },
+    gridMode: {
+        THUMBNAIL: 'thumbnail',
+        DETAILED_VIEW: 'detailed-view',
+        DETAILED: 'detailed',
+        LIST: 'list-view'
     }
 };
 

--- a/src/javascript/ContentManager/ContentRoute/ContentLayout/FilesGrid/FilesGrid.redux-reducer.js
+++ b/src/javascript/ContentManager/ContentRoute/ContentLayout/FilesGrid/FilesGrid.redux-reducer.js
@@ -1,6 +1,8 @@
+const localStorage = window.localStorage;
+
 const initialState = {
-    mode: 'grid',
-    gridMode: 'thumbnail'
+    mode: localStorage.getItem('cmm_files_selector_mode') !== null ? localStorage.getItem('cmm_files_selector_mode') : 'grid',
+    gridMode: localStorage.getItem('cmm_files_selector_grid_mode') !== null ? localStorage.getItem('cmm_files_selector_grid_mode') : 'thumbnail'
 };
 
 export const filesGrid = (state = initialState, action) => {

--- a/src/javascript/ContentManager/ContentRoute/ContentLayout/FilesGrid/FilesGrid.redux-reducer.js
+++ b/src/javascript/ContentManager/ContentRoute/ContentLayout/FilesGrid/FilesGrid.redux-reducer.js
@@ -1,8 +1,14 @@
+import ContentManagerConstants from '../../../ContentManager.constants';
+
 const localStorage = window.localStorage;
+const FILE_SELECTOR_MODE = ContentManagerConstants.localStorageKeys.filesSelectorMode;
+const FILE_SELECTOR_GRID_MODE = ContentManagerConstants.localStorageKeys.filesSelectorGridMode;
+const THUMBNAIL = ContentManagerConstants.gridMode.THUMBNAIL;
+const GRID = ContentManagerConstants.mode.GRID;
 
 const initialState = {
-    mode: localStorage.getItem('cmm_files_selector_mode') !== null ? localStorage.getItem('cmm_files_selector_mode') : 'grid',
-    gridMode: localStorage.getItem('cmm_files_selector_grid_mode') !== null ? localStorage.getItem('cmm_files_selector_grid_mode') : 'thumbnail'
+    mode: localStorage.getItem(FILE_SELECTOR_MODE) !== null ? localStorage.getItem(FILE_SELECTOR_GRID_MODE) : GRID,
+    gridMode: localStorage.getItem(FILE_SELECTOR_GRID_MODE) !== null ? localStorage.getItem(FILE_SELECTOR_GRID_MODE) : THUMBNAIL
 };
 
 export const filesGrid = (state = initialState, action) => {

--- a/src/javascript/ContentManager/ContentRoute/ContentLayout/ToolBar/FileModeSelector/FileModeSelector.jsx
+++ b/src/javascript/ContentManager/ContentRoute/ContentLayout/ToolBar/FileModeSelector/FileModeSelector.jsx
@@ -6,43 +6,53 @@ import {connect} from 'react-redux';
 import {translate} from 'react-i18next';
 import {setMode, setGridMode} from '../../FilesGrid/FilesGrid.redux-actions';
 import PropTypes from 'prop-types';
+import ContentManagerConstants from '../../../../ContentManager.constants';
 
 const localStorage = window.localStorage;
+
+const GRID = ContentManagerConstants.mode.GRID;
+const LIST = ContentManagerConstants.mode.LIST;
+const DETAILED_VIEW = ContentManagerConstants.gridMode.DETAILED_VIEW;
+const DETAILED = ContentManagerConstants.gridMode.DETAILED;
+const LIST_VIEW = ContentManagerConstants.gridMode.LIST;
+const THUMBNAIL = ContentManagerConstants.gridMode.THUMBNAIL;
+const FILE_SELECTOR_MODE = ContentManagerConstants.localStorageKeys.filesSelectorMode;
+const FILE_SELECTOR_GRID_MODE = ContentManagerConstants.localStorageKeys.filesSelectorGridMode;
 
 export const FileModeSelector = ({t, mode, gridMode, onChange, onGridMode}) => {
     const handleChange = e => {
         let selectedMode = e.target.value;
         switch (selectedMode) {
-            case 'list-view':
-                onChange('list');
-                localStorage.setItem('cmm_files_selector_mode', 'list');
+            case LIST_VIEW:
+                onChange(LIST);
+                localStorage.setItem(FILE_SELECTOR_MODE, LIST);
                 break;
-            case 'thumbnail':
-                onChange('grid');
-                localStorage.setItem('cmm_files_selector_mode', 'grid');
-                if (gridMode !== 'thumbnail') {
-                    onGridMode('thumbnail');
-                    localStorage.setItem('cmm_files_selector_grid_mode', 'thumbnail');
+            case THUMBNAIL:
+                onChange(GRID);
+                localStorage.setItem(FILE_SELECTOR_MODE, GRID);
+                if (gridMode !== THUMBNAIL) {
+                    onGridMode(THUMBNAIL);
+                    localStorage.setItem(FILE_SELECTOR_GRID_MODE, THUMBNAIL);
                 }
 
                 break;
-            case 'detailed-view':
-                onChange('grid');
-                localStorage.setItem('cmm_files_selector_mode', 'grid');
-                if (gridMode !== 'detailed') {
-                    onGridMode('detailed');
-                    localStorage.setItem('cmm_files_selector_grid_mode', 'detailed');
+            case DETAILED_VIEW:
+                onChange(GRID);
+                localStorage.setItem(FILE_SELECTOR_MODE, GRID);
+                if (gridMode !== DETAILED) {
+                    onGridMode(DETAILED);
+                    localStorage.setItem(FILE_SELECTOR_GRID_MODE, DETAILED);
                 }
 
                 break;
             default:
-                if (mode === 'list') {
-                    onChange('grid');
+                if (mode === LIST) {
+                    onChange(GRID);
                 }
         }
     };
 
-    let select = mode === 'grid' && gridMode === 'thumbnail' ? 'thumbnail' : (mode === 'grid' ? 'detailed-view' : 'list-view');
+    let select = mode === GRID && gridMode === THUMBNAIL ? THUMBNAIL : (mode === GRID ? DETAILED_VIEW : LIST_VIEW);
 
     return (
         <Select
@@ -52,9 +62,9 @@ export const FileModeSelector = ({t, mode, gridMode, onChange, onGridMode}) => {
             variant="ghost"
             onChange={e => handleChange(e)}
         >
-            <MenuItem value="thumbnail">{t('label.contentManager.filesGrid.selectThumbnailView')}</MenuItem>
-            <MenuItem value="list-view">{t('label.contentManager.filesGrid.selectListView')}</MenuItem>
-            <MenuItem value="detailed-view">{t('label.contentManager.filesGrid.selectDetailedView')}</MenuItem>
+            <MenuItem value={THUMBNAIL}>{t('label.contentManager.filesGrid.selectThumbnailView')}</MenuItem>
+            <MenuItem value={LIST_VIEW}>{t('label.contentManager.filesGrid.selectListView')}</MenuItem>
+            <MenuItem value={DETAILED_VIEW}>{t('label.contentManager.filesGrid.selectDetailedView')}</MenuItem>
         </Select>
     );
 };

--- a/src/javascript/ContentManager/ContentRoute/ContentLayout/ToolBar/FileModeSelector/FileModeSelector.jsx
+++ b/src/javascript/ContentManager/ContentRoute/ContentLayout/ToolBar/FileModeSelector/FileModeSelector.jsx
@@ -7,24 +7,31 @@ import {translate} from 'react-i18next';
 import {setMode, setGridMode} from '../../FilesGrid/FilesGrid.redux-actions';
 import PropTypes from 'prop-types';
 
+const localStorage = window.localStorage;
+
 export const FileModeSelector = ({t, mode, gridMode, onChange, onGridMode}) => {
     const handleChange = e => {
         let selectedMode = e.target.value;
         switch (selectedMode) {
             case 'list-view':
                 onChange('list');
+                localStorage.setItem('cmm_files_selector_mode', 'list');
                 break;
             case 'thumbnail':
                 onChange('grid');
+                localStorage.setItem('cmm_files_selector_mode', 'grid');
                 if (gridMode !== 'thumbnail') {
                     onGridMode('thumbnail');
+                    localStorage.setItem('cmm_files_selector_grid_mode', 'thumbnail');
                 }
 
                 break;
             case 'detailed-view':
                 onChange('grid');
+                localStorage.setItem('cmm_files_selector_mode', 'grid');
                 if (gridMode !== 'detailed') {
                     onGridMode('detailed');
+                    localStorage.setItem('cmm_files_selector_grid_mode', 'detailed');
                 }
 
                 break;


### PR DESCRIPTION
…sh and keep same user's choice

<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/QA-12188

## Description
store file-grid-modes into local storage in order to keep user's choice after refresh
<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
